### PR TITLE
Feature conn class

### DIFF
--- a/conn2res/coding.py
+++ b/conn2res/coding.py
@@ -15,14 +15,14 @@ def get_modules(module_assignment):
     """
     #TODO
     """
-    # get module ids 
+    # get module ids
     module_ids = np.unique(module_assignment)
     readout_modules = [np.where(module_assignment == i)[0] for i in module_ids]
 
-    return  module_ids, readout_modules
+    return module_ids, readout_modules
 
 
-def encoder(reservoir_states, target, readout_modules=None,\
+def encoder(reservoir_states, target, readout_modules=None,
             readout_nodes=None, *args, **kwargs):
     """
     Function that defines the set(s) of readout nodes based on whether
@@ -65,40 +65,41 @@ def encoder(reservoir_states, target, readout_modules=None,\
 
     if readout_modules is not None:
 
-        if isinstance(readout_modules, np.ndarray): 
+        if isinstance(readout_modules, np.ndarray):
             module_ids, readout_modules = get_modules(readout_modules)
-        
+
         elif isinstance(readout_modules, dict):
-            module_ids      = list(readout_modules.keys())
+            module_ids = list(readout_modules.keys())
             readout_modules = list(readout_modules.values())
 
-        elif isinstance(readout_modules, list):            
+        elif isinstance(readout_modules, list):
             module_ids = np.arange(len(readout_modules))
-        
+
         # perform task using as readout nodes every module in readout_modules
         df_encoding = []
         for i, readout_nodes in enumerate(readout_modules):
 
-            print(f'\t   -- Module : {module_ids[i]} with {len(readout_nodes)} nodes --')
+            print(
+                f'\t   -- Module : {module_ids[i]} with {len(readout_nodes)} nodes --')
 
             # create temporal dataframe
-            df_module = run_task(reservoir_states=(reservoir_states[0][:,readout_nodes], reservoir_states[1][:,readout_nodes]), # reservoir_states[:,:,readout_nodes],
+            df_module = run_task(reservoir_states=(reservoir_states[0][:, readout_nodes], reservoir_states[1][:, readout_nodes]),  # reservoir_states[:,:,readout_nodes],
                                  target=target, **kwargs)
 
             df_module['module'] = module_ids[i]
             df_module['n_nodes'] = len(readout_nodes)
 
-            #get encoding scores
+            # get encoding scores
             df_encoding.append(df_module)
 
         df_encoding = pd.concat(df_encoding)
 
     elif readout_nodes is not None:
-        df_encoding = run_task(reservoir_states=(reservoir_states[0][:,readout_nodes], reservoir_states[1][:,readout_nodes]),
+        df_encoding = run_task(reservoir_states=(reservoir_states[0][:, readout_nodes], reservoir_states[1][:, readout_nodes]),
                                target=target, **kwargs)
 
         df_encoding['n_nodes'] = len(readout_nodes)
-    
+
     else:
         df_encoding = run_task(reservoir_states=reservoir_states,
                                target=target, **kwargs)

--- a/conn2res/iodata.py
+++ b/conn2res/iodata.py
@@ -14,6 +14,9 @@ import seaborn as sns
 
 from .task import select_model
 
+PROJ_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DATA_DIR = os.path.join(PROJ_DIR, 'examples', 'data')
+
 NEUROGYM_TASKS = [
     'AntiReach',
     # 'Bandit',
@@ -53,6 +56,10 @@ NATIVE_TASKS = [
     'MemoryCapacity',
     # 'TemporalPatternRecognition'
 ]
+
+
+def load_file(filename):
+    return np.load(os.path.join(DATA_DIR, filename))
 
 
 def get_available_tasks():

--- a/conn2res/iodata.py
+++ b/conn2res/iodata.py
@@ -9,10 +9,9 @@ import os
 from re import I
 import numpy as np
 import neurogym as ngym
-import matplotlib.pyplot as plt
-import seaborn as sns
 
 from .task import select_model
+from . import plotting
 
 PROJ_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DATA_DIR = os.path.join(PROJ_DIR, 'examples', 'data')
@@ -252,18 +251,4 @@ def visualize_data(task, x, y, plot=True):
     print(f'\tmodel = {model.__name__}')
 
     if plot:
-        fig = plt.figure(num=1, figsize=(12, 10))
-        ax = plt.subplot(111)
-
-        x_labels = [f'I{n+1}' for n in range(n_features)]
-        y_labels = [f'O{n+1}' for n in range(n_labels)]
-
-        plt.plot(x[:], label=x_labels)
-        plt.plot(y[:], label=y_labels)
-        plt.legend()
-        plt.suptitle(task)
-
-        sns.despine(offset=10, trim=True)
-        # fig.savefig(fname=f'figs/{task}_io.png', transparent=True, bbox_inches='tight', dpi=300)
-        plt.show()
-        plt.close()
+        plotting.plot_task(x, y, task)

--- a/conn2res/iodata.py
+++ b/conn2res/iodata.py
@@ -15,48 +15,48 @@ import seaborn as sns
 from .task import select_model
 
 NEUROGYM_TASKS = [
-                'AntiReach',
-                # 'Bandit',
-                'ContextDecisionMaking',
-                # 'DawTwoStep',
-                'DelayComparison',
-                'DelayMatchCategory',
-                'DelayMatchSample',
-                'DelayMatchSampleDistractor1D',
-                'DelayPairedAssociation',
-                # 'Detection',  # TODO: Temporary removing until bug fixed
-                'DualDelayMatchSample',
-                # 'EconomicDecisionMaking',
-                'GoNogo',
-                # 'HierarchicalReasoning',
-                'IntervalDiscrimination',
-                'MotorTiming',
-                'MultiSensoryIntegration',
-                # 'Null',
-                'OneTwoThreeGo',
-                'PerceptualDecisionMaking',
-                'PerceptualDecisionMakingDelayResponse',
-                'PostDecisionWager',
-                'ProbabilisticReasoning',
-                'PulseDecisionMaking',
-                'Reaching1D',
-                'Reaching1DWithSelfDistraction',
-                'ReachingDelayResponse',
-                'ReadySetGo',
-                'SingleContextDecisionMaking',
-                'SpatialSuppressMotion',
-                # 'ToneDetection'  # TODO: Temporary removing until bug fixed
-            ]
+    'AntiReach',
+    # 'Bandit',
+    'ContextDecisionMaking',
+    # 'DawTwoStep',
+    'DelayComparison',
+    'DelayMatchCategory',
+    'DelayMatchSample',
+    'DelayMatchSampleDistractor1D',
+    'DelayPairedAssociation',
+    # 'Detection',  # TODO: Temporary removing until bug fixed
+    'DualDelayMatchSample',
+    # 'EconomicDecisionMaking',
+    'GoNogo',
+    # 'HierarchicalReasoning',
+    'IntervalDiscrimination',
+    'MotorTiming',
+    'MultiSensoryIntegration',
+    # 'Null',
+    'OneTwoThreeGo',
+    'PerceptualDecisionMaking',
+    'PerceptualDecisionMakingDelayResponse',
+    'PostDecisionWager',
+    'ProbabilisticReasoning',
+    'PulseDecisionMaking',
+    'Reaching1D',
+    'Reaching1DWithSelfDistraction',
+    'ReachingDelayResponse',
+    'ReadySetGo',
+    'SingleContextDecisionMaking',
+    'SpatialSuppressMotion',
+    # 'ToneDetection'  # TODO: Temporary removing until bug fixed
+]
 
 
 NATIVE_TASKS = [
-                'MemoryCapacity',
-                # 'TemporalPatternRecognition'  
-                ]
+    'MemoryCapacity',
+    # 'TemporalPatternRecognition'
+]
 
 
 def get_available_tasks():
-    return NEUROGYM_TASKS #+ NATIVE_TASKS
+    return NEUROGYM_TASKS  # + NATIVE_TASKS
 
 
 def unbatch(x):
@@ -74,7 +74,7 @@ def unbatch(x):
         new array with dimensions (batch_size*seq_len, features)
 
     """
-    #TODO right now it only works when x is (batch_first = False)
+    # TODO right now it only works when x is (batch_first = False)
     return np.concatenate(x, axis=0)
 
 
@@ -85,8 +85,9 @@ def encode_labels(labels):
         #TODO
     """
 
-    enc_labels = -1 * np.ones((labels.shape[0], len(np.unique(labels))), dtype=np.int16)
-    
+    enc_labels = -1 * \
+        np.ones((labels.shape[0], len(np.unique(labels))), dtype=np.int16)
+
     for i, label in enumerate(labels):
         enc_labels[i][label] = 1
 
@@ -114,7 +115,7 @@ def fetch_dataset(task, n_trials=100, *args, **kwargs):
     'SingleContextDecisionMaking', 'SpatialSuppressMotion',
     'ToneDetection'}
     Task to be performed
-    
+
     unbatch_data : bool, optional
         If True, it adds an extra dimension to inputs and labels 
         that corresponds to the batch_size. Otherwise, it returns an
@@ -135,7 +136,7 @@ def fetch_dataset(task, n_trials=100, *args, **kwargs):
         kwargs = {'dt': 100}
         dataset = ngym.Dataset(task+'-v0', env_kwargs=kwargs)
 
-        # get environment object 
+        # get environment object
         env = dataset.env
 
         # generate per trial dataset
@@ -150,11 +151,13 @@ def fetch_dataset(task, n_trials=100, *args, **kwargs):
             inputs.append(ob)
 
             # store labels
-            if gt.ndim == 1: labels.append(gt[:, np.newaxis])
-            else: labels.append(gt)
+            if gt.ndim == 1:
+                labels.append(gt[:, np.newaxis])
+            else:
+                labels.append(gt)
 
     elif task in NATIVE_TASKS:
-        # create a native conn2res Dataset 
+        # create a native conn2res Dataset
         inputs, labels = create_nativet_dataset(task, **kwargs)
 
     return inputs, labels
@@ -163,14 +166,13 @@ def fetch_dataset(task, n_trials=100, *args, **kwargs):
 def create_nativet_dataset(task, tau_max=20, **kwargs):
 
     if task == 'MemoryCapacity':
-        x = np.random.uniform(-1, 1, (1000+tau_max))[:,np.newaxis]
-        y = np.hstack([x[tau_max-tau:-tau] for tau in range(1,tau_max+1)])
-    
+        x = np.random.uniform(-1, 1, (1000+tau_max))[:, np.newaxis]
+        y = np.hstack([x[tau_max-tau:-tau] for tau in range(1, tau_max+1)])
+
     return x, y
 
 
 def split_dataset(data, frac_train=0.7):
-
     """
     Splits data into training and test sets according to
     'frac_train'
@@ -207,29 +209,35 @@ def visualize_data(task, x, y, plot=True):
     ----------
     task : str
     x,y  : list or numpy.ndarray
-        
+
     """
 
     print(f'\n----- {task.upper()} -----')
     print(f'\tNumber of trials = {len(x)}')
 
     # convert x and y to arrays for visualization
-    if isinstance(x, list): x = np.vstack(x[:5])
-    if isinstance(y, list): y = np.vstack(y[:5]).squeeze()
+    if isinstance(x, list):
+        x = np.vstack(x[:5])
+    if isinstance(y, list):
+        y = np.vstack(y[:5]).squeeze()
 
     print(f'\tinputs shape = {x.shape}')
     print(f'\tlabels shape = {y.shape}')
 
-    # number of features, labels and classes 
-    try: n_features = x.shape[1]
-    except: n_features = 1
+    # number of features, labels and classes
+    try:
+        n_features = x.shape[1]
+    except:
+        n_features = 1
 
-    try: n_labels = y.shape[1]
-    except: n_labels = 1
+    try:
+        n_labels = y.shape[1]
+    except:
+        n_labels = 1
     n_classes = len(np.unique(y))
 
     model = select_model(y)
-    
+
     print(f'\t  n_features = {n_features}')
     print(f'\tn_labels   = {n_labels}')
     print(f'\tn_classes  = {n_classes}')
@@ -237,20 +245,18 @@ def visualize_data(task, x, y, plot=True):
     print(f'\tmodel = {model.__name__}')
 
     if plot:
-        fig = plt.figure(num=1, figsize=(12,10))
+        fig = plt.figure(num=1, figsize=(12, 10))
         ax = plt.subplot(111)
 
-        x_labels  = [f'I{n+1}' for n in range(n_features)]
+        x_labels = [f'I{n+1}' for n in range(n_features)]
         y_labels = [f'O{n+1}' for n in range(n_labels)]
 
         plt.plot(x[:], label=x_labels)
         plt.plot(y[:], label=y_labels)
         plt.legend()
         plt.suptitle(task)
-        
+
         sns.despine(offset=10, trim=True)
         # fig.savefig(fname=f'figs/{task}_io.png', transparent=True, bbox_inches='tight', dpi=300)
         plt.show()
         plt.close()
-    
-

--- a/conn2res/plotting.py
+++ b/conn2res/plotting.py
@@ -65,8 +65,8 @@ def plot_performance_curve(df, title, num=2, figsize=(12, 10), savefig=False, bl
                  ax=ax)
 
     sns.despine(offset=10, trim=True)
+    plt.title(title)
     if savefig:
         fig.savefig(fname=os.path.join(FIG_DIR, f'{title}_score.png'),
                     transparent=True, bbox_inches='tight', dpi=300)
-    plt.title(title)
     plt.show(block=block)

--- a/conn2res/plotting.py
+++ b/conn2res/plotting.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""
+Plotting functions
+
+@author: Estefany Suarez
+"""
+
+import os
+import seaborn as sns
+import matplotlib.pyplot as plt
+import numpy as np
+
+PROJ_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FIG_DIR = os.path.join(PROJ_DIR, 'figs')
+if not os.path.isdir(FIG_DIR):
+    os.makedirs(FIG_DIR)
+
+
+def plot_task(x, y, title, num=1, figsize=(12, 10), savefig=False, block=True):
+
+    fig = plt.figure(num=num, figsize=figsize)
+    ax = plt.subplot(111)
+
+    # xlabels, ylabels
+    try:
+        x_labels = [f'I{n+1}' for n in range(x.shape[1])]
+    except:
+        x_labels = 'I1'
+    try:
+        y_labels = [f'O{n+1}' for n in range(y.shape[1])]
+    except:
+        y_labels = 'O1'
+
+    plt.plot(x[:], label=x_labels)
+    plt.plot(y[:], label=y_labels)
+    plt.legend()
+    plt.suptitle(title)
+
+    sns.despine(offset=10, trim=True)
+    if savefig:
+        fig.savefig(fname=os.path.join(FIG_DIR, f'{title}_io.png'),
+                    transparent=True, bbox_inches='tight', dpi=300)
+    plt.show(block=block)
+
+
+def plot_performance_curve(df, title, num=2, figsize=(12, 10), savefig=False, block=True):
+
+    sns.set(style="ticks", font_scale=2.0)
+    fig = plt.figure(num=num, figsize=figsize)
+    ax = plt.subplot(111)
+
+    n_modules = len(np.unique(df['module']))
+    palette = sns.color_palette('husl', n_modules+1)[:n_modules]
+
+    if 'VIS' in list(np.unique(df['module'])):
+        hue_order = ['VIS', 'SM', 'DA', 'VA', 'LIM', 'FP', 'DMN']
+    else:
+        hue_order = None
+
+    sns.lineplot(data=df, x='alpha', y='score',
+                 hue='module',
+                 hue_order=hue_order,
+                 palette=palette,
+                 markers=True,
+                 ax=ax)
+
+    sns.despine(offset=10, trim=True)
+    if savefig:
+        fig.savefig(fname=os.path.join(FIG_DIR, f'{title}_score.png'),
+                    transparent=True, bbox_inches='tight', dpi=300)
+    plt.title(title)
+    plt.show(block=block)

--- a/conn2res/reservoir.py
+++ b/conn2res/reservoir.py
@@ -12,6 +12,7 @@ from numpy.linalg import (pinv, matrix_rank)
 
 import matplotlib.pyplot as plt
 
+
 class Reservoir:
     """
     Class that represents a general Reservoir object
@@ -35,6 +36,7 @@ class Reservoir:
     ----------
 
     """
+
     def __init__(self, w_ih, w_hh, *args, **kwargs):
         """
         Constructor class for general Reservoir Networks
@@ -103,8 +105,8 @@ class EchoStateNetwork(Reservoir):
         """
         super().__init__(*args, **kwargs)
 
-        self.activation_function = self.set_activation_function(activation_function)
-
+        self.activation_function = self.set_activation_function(
+            activation_function)
 
     def simulate(self, ext_input, ic=None, threshold=0.5):
         """
@@ -133,25 +135,27 @@ class EchoStateNetwork(Reservoir):
         # print('\n GENERATING RESERVOIR STATES ...')
 
         # check data type for ext_input. If list convert to numpy.ndarray
-        if isinstance(ext_input, list): ext_input = np.asarray(ext_input)
+        if isinstance(ext_input, list):
+            ext_input = np.asarray(ext_input)
 
         # initialize reservoir states
         timesteps = range(1, len(ext_input))
         self._state = np.zeros((len(timesteps)+1, self.hidden_size))
 
         # set initial conditions
-        if ic is not None: self._state[0,:] = ic
+        if ic is not None:
+            self._state[0, :] = ic
 
         # simulation of the dynamics
         for t in timesteps:
 
             # if (t>0) and (t%100 == 0): print(f'\t ----- timestep = {t}')
 
-            synap_input = np.dot(self._state[t-1,:], self.w_hh) + np.dot(ext_input[t-1,:], self.w_ih)
-            self._state[t,:] = self.activation_function(synap_input)
+            synap_input = np.dot(
+                self._state[t-1, :], self.w_hh) + np.dot(ext_input[t-1, :], self.w_ih)
+            self._state[t, :] = self.activation_function(synap_input)
 
         return self._state
-
 
     def set_activation_function(self, function):
 
@@ -159,7 +163,7 @@ class EchoStateNetwork(Reservoir):
             return m * x
 
         def elu(x, alpha=0.5):
-            x[x <= 0] = alpha*(np.exp(x[x <= 0]) -1)
+            x[x <= 0] = alpha*(np.exp(x[x <= 0]) - 1)
             return x
 
         def relu(x):
@@ -175,7 +179,7 @@ class EchoStateNetwork(Reservoir):
             return np.tanh(x)
 
         def step(x, thr=0.5, vmin=0, vmax=1):
-            return np.piecewise(x, [x<thr, x>=thr], [vmin, vmax]).astype(int)
+            return np.piecewise(x, [x < thr, x >= thr], [vmin, vmax]).astype(int)
 
         if function == 'linear':
             return linear
@@ -235,6 +239,7 @@ class MemristiveReservoir:
     #TODO
 
     """
+
     def __init__(self, w, int_nodes, ext_nodes, gr_nodes, save_conductance=False, *args, **kwargs):
         """
         Constructor class for Memristive Networks. Memristive networks are an
@@ -261,9 +266,9 @@ class MemristiveReservoir:
             increase memory demands. Default: False
         """
         # super().__init__(*args, **kwargs)
-        self._W  = self.setW(w)
-        self._I  = np.asarray(int_nodes)
-        self._E  = np.asarray(ext_nodes)
+        self._W = self.setW(w)
+        self._I = np.asarray(int_nodes)
+        self._E = np.asarray(ext_nodes)
         self._GR = np.asarray(gr_nodes)
 
         self._n_internal_nodes = len(self._I)
@@ -277,7 +282,6 @@ class MemristiveReservoir:
         self._G_history = None
 
         self._state = None
-
 
     def setW(self, w):
         """
@@ -307,15 +311,14 @@ class MemristiveReservoir:
 
             # matrix of undirected connections
             W = np.zeros_like(w).astype(int)
-            W[np.triu_indices_from(w,1)] = np.logical_or(upper_diag,
-                                                         lower_diag
-                                                        ).astype(int)
+            W[np.triu_indices_from(w, 1)] = np.logical_or(upper_diag,
+                                                          lower_diag
+                                                          ).astype(int)
 
             return make_symmetric(W, copy_lower=False)
 
         else:
             return w
-
 
     def init_property(self, mean, std=0.1):
         """
@@ -335,8 +338,7 @@ class MemristiveReservoir:
         p = np.random.normal(mean, std*mean, size=self._W.shape)
         p = make_symmetric(p)
 
-        return p * self._W # ma.masked_array(p, mask=np.logical_not(self._W))
-
+        return p * self._W  # ma.masked_array(p, mask=np.logical_not(self._W))
 
     def solveVi(self, Ve, Vgr=None, G=None, **kwargs):
         """
@@ -354,8 +356,10 @@ class MemristiveReservoir:
 
         """
 
-        if Vgr is None: Vgr = np.zeros((self._n_grounded_nodes))
-        if G is None: G = self._G
+        if Vgr is None:
+            Vgr = np.zeros((self._n_grounded_nodes))
+        if G is None:
+            G = self._G
 
         # TODO: verify that the axis along which the sum is performed is correct
         # matrix N
@@ -371,14 +375,13 @@ class MemristiveReservoir:
         A_II_inv = pinv(A_II)
 
         # matrix HI
-        H_IE  = np.dot(G[np.ix_(self._I, self._E)], Ve)
+        H_IE = np.dot(G[np.ix_(self._I, self._E)], Ve)
         H_IGR = np.dot(G[np.ix_(self._I, self._GR)], Vgr)
 
         H_I = H_IE + H_IGR
 
         # return voltage at internal nodes
         return np.dot(A_II_inv, H_I)
-
 
     def getV(self, Vi, Ve, Vgr=None):
         """
@@ -397,27 +400,29 @@ class MemristiveReservoir:
         """
 
         # set voltage at grounded nodes
-        if Vgr is None: Vgr = np.zeros((self._n_grounded_nodes))
+        if Vgr is None:
+            Vgr = np.zeros((self._n_grounded_nodes))
 
         # set of all nodal voltages
-        voltage = np.concatenate([Vi[:, np.newaxis], Ve[:, np.newaxis], Vgr[:, np.newaxis]]).squeeze()
+        voltage = np.concatenate(
+            [Vi[:, np.newaxis], Ve[:, np.newaxis], Vgr[:, np.newaxis]]).squeeze()
 
         # set of all nodes (internal + external + grounded)
-        nodes   = np.concatenate([self._I[:, np.newaxis], self._E[:, np.newaxis], self._GR[:, np.newaxis]]).squeeze()
+        nodes = np.concatenate(
+            [self._I[:, np.newaxis], self._E[:, np.newaxis], self._GR[:, np.newaxis]]).squeeze()
 
         # dictionary that groups pairs of voltage
-        nv_dict = {n:v for n,v in zip(nodes,voltage)}
+        nv_dict = {n: v for n, v in zip(nodes, voltage)}
 
         # voltage across memristors
         V = np.zeros_like(self._W).astype(float)
-        for i,j in list(zip(*np.where(self._W != 0))):
+        for i, j in list(zip(*np.where(self._W != 0))):
             if j > i:
-                V[i,j] = nv_dict[i] - nv_dict[j]
+                V[i, j] = nv_dict[i] - nv_dict[j]
             else:
-                V[i,j] = nv_dict[j] - nv_dict[i]
+                V[i, j] = nv_dict[j] - nv_dict[i]
 
         return mask(self, V)
-
 
     def simulate(self, Vext, ic=None, mode='forward'):
         """
@@ -458,24 +463,25 @@ class MemristiveReservoir:
         for t, Ve in enumerate(Vext):
             if mode == 'forward':
 
-                    if (t>0) and (t%100 == 0): print(f'\t ----- timestep = {t}')
+                if (t > 0) and (t % 100 == 0):
+                    print(f'\t ----- timestep = {t}')
 
-                    # get voltage at internal nodes
-                    Vi = self.solveVi(Ve)
+                # get voltage at internal nodes
+                Vi = self.solveVi(Ve)
 
-                    # update matrix of voltages across memristors
-                    V = self.getV(Vi, Ve)
+                # update matrix of voltages across memristors
+                V = self.getV(Vi, Ve)
 
-                    # update conductance
-                    self.updateG(V=V, update=True)
-
+                # update conductance
+                self.updateG(V=V, update=True)
 
             elif mode == 'backward':
 
-                    if (t>0) and (t%100 == 0): print(f'\t ----- timestep = {t}')
+                if (t > 0) and (t % 100 == 0):
+                    print(f'\t ----- timestep = {t}')
 
-                    # get voltage at internal nodes
-                    Vi = self.iterate(Ve)
+                # get voltage at internal nodes
+                Vi = self.iterate(Ve)
 
             # store activation states
             self._state[t, self._E] = Ve
@@ -487,7 +493,6 @@ class MemristiveReservoir:
 
         return self._state
 
-
     def iterate(self, Ve, tol=5e-2, iters=100):
         """
         #TODO
@@ -498,7 +503,7 @@ class MemristiveReservoir:
         Vi = [self.solveVi(Ve=Ve, G=self._G)]
 
         # initial guess for conductance
-        G  = [self._G]
+        G = [self._G]
 
         convergence = False
         n_iters = 0
@@ -515,13 +520,14 @@ class MemristiveReservoir:
             Vi.append(self.solveVi(Ve=Ve, G=G_tmp))
 
             # update conductance with G_tmp
-            G.append(self.updateG(V, G_tmp, update=False)) # supposedly correct
+            # supposedly correct
+            G.append(self.updateG(V, G_tmp, update=False))
             # G.append(self.updateG(self.getV(Vi[-1].copy(), Ve), G[-1], update=False))
             # G.append(self.updateG(self.getV(Vi[-1].copy(), Ve), G_tmp, update=False))
 
             # estimate error
             err_Vi = self.getErr(Vi[-2], Vi[-1])
-            err_G  = self.getErr(G[-2], G[-1])
+            err_G = self.getErr(G[-2], G[-1])
 
             max_err = np.max((np.max(err_Vi), np.max(err_G)))
             if max_err < tol:
@@ -537,7 +543,6 @@ class MemristiveReservoir:
             # print(f'\t\t\t max error = {max_err}')
 
         return Vi[-1]
-
 
     def getErr(self, x_0, x_1):
         """
@@ -613,7 +618,7 @@ class MSSNetwork(MemristiveReservoir):
     b = Q/(k*Temp)
     VT = 1/b
 
-    def __init__(self, vA=0.17, vB=0.22, tc=0.32e-3, NMSS=10000,\
+    def __init__(self, vA=0.17, vB=0.22, tc=0.32e-3, NMSS=10000,
                  Woff=0.91e-3, Won=0.87e-2, Nb=2000, noise=0.1, *args, **kwargs):
         """
         Constructor class for Memristive Networks following the Generalized
@@ -660,22 +665,21 @@ class MSSNetwork(MemristiveReservoir):
         """
         super().__init__(*args, **kwargs)
 
-        self.vA     = self.init_property(vA, noise)      # constant
-        self.vB     = self.init_property(vB, noise)      # constant
-        self.tc     = self.init_property(tc, noise)      # constant
-        self.NMSS   = self.init_property(NMSS, noise)    # constant
-        self.Woff   = self.init_property(Woff, noise)    # constant
-        self.Won    = self.init_property(Won, noise)     # constant
-        self._Ga    = np.divide(self.Woff, self.NMSS,
-                                where=self.NMSS!=0,
-                                out=np.zeros_like(self.Woff))  # constant
-        self._Gb    = np.divide(self.Won, self.NMSS,
-                                where=self.NMSS!=0,
-                                out=np.zeros_like(self.Won))   # constant
+        self.vA = self.init_property(vA, noise)      # constant
+        self.vB = self.init_property(vB, noise)      # constant
+        self.tc = self.init_property(tc, noise)      # constant
+        self.NMSS = self.init_property(NMSS, noise)    # constant
+        self.Woff = self.init_property(Woff, noise)    # constant
+        self.Won = self.init_property(Won, noise)     # constant
+        self._Ga = np.divide(self.Woff, self.NMSS,
+                             where=self.NMSS != 0,
+                             out=np.zeros_like(self.Woff))  # constant
+        self._Gb = np.divide(self.Won, self.NMSS,
+                             where=self.NMSS != 0,
+                             out=np.zeros_like(self.Won))   # constant
 
-        self._Nb     = self.init_property(Nb, noise)
-        self._G      = self._Nb * (self._Gb - self._Ga) + self.NMSS * self._Ga
-
+        self._Nb = self.init_property(Nb, noise)
+        self._G = self._Nb * (self._Gb - self._Ga) + self.NMSS * self._Ga
 
     def dG(self, V, G=None, dt=1e-4):
         """
@@ -733,17 +737,17 @@ class MSSNetwork(MemristiveReservoir):
 
         return dNb
 
-
     def updateG(self, V, G=None, update=False):
         """
         # TODO
         """
 
-        if G is None: G = self._G
+        if G is None:
+            G = self._G
 
         # compute dG
         dNb = self.dG(V=V, G=G)
-        dG  = dNb * (self._Gb-self._Ga)
+        dG = dNb * (self._Gb-self._Ga)
 
         if update:
             # update Nb
@@ -754,7 +758,7 @@ class MSSNetwork(MemristiveReservoir):
             # self._G += dG
 
         else:
-            return self._G.copy() + dG # updated conductance
+            return self._G.copy() + dG  # updated conductance
 
 
 def reservoir(name, *args, **kwargs):
@@ -788,9 +792,9 @@ def check_symmetric(a, tol=1e-16):
 
 def make_symmetric(a, copy_lower=True):
     if copy_lower:
-        return np.tril(a,-1) + np.tril(a,-1).T
+        return np.tril(a, -1) + np.tril(a, -1).T
     else:
-        return np.triu(a,1) + np.triu(a,1).T
+        return np.triu(a, 1) + np.triu(a, 1).T
 
 
 def check_square(a):
@@ -801,5 +805,7 @@ def check_square(a):
     """
 
     s = a.shape
-    if s[0] == s[1]: return True
-    else: return False
+    if s[0] == s[1]:
+        return True
+    else:
+        return False

--- a/conn2res/reservoir.py
+++ b/conn2res/reservoir.py
@@ -109,7 +109,7 @@ class Conn:
         self._update_nodes(idx_node)
 
         # update component
-        self._update_component()
+        self._get_largest_component()
 
     def get_nodes(self, node_set, nodes_from=None, nodes_without=None, n_nodes=1, **kwargs):
         """
@@ -199,16 +199,18 @@ class Conn:
 
         return selected_nodes
 
-    def _update_component(self):
+    def _get_largest_component(self):
         """
         Updates a set of nodes so that they belong to one connected component
 
         #TODO
         """
 
-        # make sure that the connectivity matrix consists of one large component
+        # get all components of the connectivity matrix
         comps, comp_sizes = get_components(self.w)
-        idx_node = comps == np.where(comp_sizes != 1)[0] + 1
+
+        # get indexes pertaining to the largest component
+        idx_node = comps == np.argmax(comp_sizes) + 1
 
         # update node attributes
         self._update_nodes(idx_node)

--- a/conn2res/reservoir.py
+++ b/conn2res/reservoir.py
@@ -93,7 +93,7 @@ class Conn:
         # binarize connectivity matrix
         self.w = self.w.astype(bool).astype(int)
 
-    def subset_nodes(self, node_set, **kwargs):
+    def subset_nodes(self, node_set='all', idx_node=None, **kwargs):
         """
         Defines subset of nodes of the connectivity matrix and reduces
         the connectivity matrix to this subset
@@ -102,8 +102,9 @@ class Conn:
         """
 
         # get nodes
-        idx_node = np.isin(np.arange(self.n_nodes),
-                           self.get_nodes(node_set, **kwargs))
+        if idx_node is None:
+            idx_node = np.isin(np.arange(self.n_nodes),
+                               self.get_nodes(node_set, **kwargs))
 
         # update node attributes
         self._update_nodes(idx_node)

--- a/conn2res/reservoir.py
+++ b/conn2res/reservoir.py
@@ -31,12 +31,16 @@ class Conn:
     # TODO
     """
 
-    def __init__(self, subj_id=0):
-        # load connectivity data
-        self.w = load_file('connectivity.npy')
+    def __init__(self, subj_id=0, w=None):
+        if w is not None:
+            # assign provided connectivity data
+            self.w = w
+        else:
+            # load connectivity data
+            self.w = load_file('connectivity.npy')
 
-        # select one subject
-        self.w = self.w[:, :, subj_id]
+            # select one subject
+            self.w = self.w[:, :, subj_id]
 
         # number of all active nodes
         self.n_nodes = len(self.w)

--- a/conn2res/reservoir.py
+++ b/conn2res/reservoir.py
@@ -10,8 +10,6 @@ import numpy as np
 import numpy.ma as ma
 from numpy.linalg import (pinv, matrix_rank)
 
-import matplotlib.pyplot as plt
-
 
 class Reservoir:
     """

--- a/conn2res/task.py
+++ b/conn2res/task.py
@@ -9,7 +9,7 @@ tasks
 import numpy as np
 import pandas as pd
 import scipy as sp
-import mdp
+# import mdp
 
 from sklearn import metrics
 from sklearn.model_selection import ParameterGrid

--- a/conn2res/task.py
+++ b/conn2res/task.py
@@ -22,7 +22,7 @@ from sklearn.ensemble import RandomForestRegressor
 import matplotlib.pyplot as plt
 
 
-def check_xy_dims(x,y):
+def check_xy_dims(x, y):
     """
     Check that X,Y have the right dimensions
     #TODO
@@ -32,13 +32,13 @@ def check_xy_dims(x,y):
 
     if ((x_train.ndim == 1) and (x_test.ndim == 1)):
         x_train = x_train[:, np.newaxis]
-        x_test  = x_test[:, np.newaxis]
+        x_test = x_test[:, np.newaxis]
     elif ((x_train.ndim > 2) and (x_test.ndim > 2)):
         x_train = x_train.squeeze()
-        x_test  = x_test.squeeze()
+        x_test = x_test.squeeze()
 
     y_train = y_train.squeeze()
-    y_test  = y_test.squeeze()
+    y_test = y_test.squeeze()
 
     return x_train, x_test, y_train, y_test
 
@@ -52,7 +52,8 @@ def regression(x, y, **kwargs):
     x_train, x_test = x
     y_train, y_test = y
 
-    model = Ridge(fit_intercept=False, alpha=0.5, **kwargs).fit(x_train, y_train)
+    model = Ridge(fit_intercept=False, alpha=0.5,
+                  **kwargs).fit(x_train, y_train)
     score = model.score(x_test, y_test)
 
     return score
@@ -67,14 +68,16 @@ def multiOutputRegression(x, y, **kwargs):
     x_train, x_test = x
     y_train, y_test = y
 
-    model = MultiOutputRegressor(Ridge(fit_intercept=False, alpha=0.5, **kwargs)).fit(x_train, y_train)
+    model = MultiOutputRegressor(
+        Ridge(fit_intercept=False, alpha=0.5, **kwargs)).fit(x_train, y_train)
 
     y_pred = model.predict(x_test)
     n_outputs = y_pred.shape[1]
 
     score = []
     for output in range(n_outputs):
-        score.append(np.abs((np.corrcoef(y_test[:,output], y_pred[:,output])[0][1])))
+        score.append(
+            np.abs((np.corrcoef(y_test[:, output], y_pred[:, output])[0][1])))
 
     return np.sum(score)
 
@@ -88,8 +91,9 @@ def classification(x, y, **kwargs):
     x_train, x_test = x
     y_train, y_test = y
 
-    model = RidgeClassifier(alpha=0.0, fit_intercept=True, **kwargs).fit(x_train, y_train)
-    score  = model.score(x_test, y_test)
+    model = RidgeClassifier(alpha=0.0, fit_intercept=True,
+                            **kwargs).fit(x_train, y_train)
+    score = model.score(x_test, y_test)
 
     # # confusion matrix
     # ConfusionMatrixDisplay.from_predictions(y_test, model.predict(x_test))
@@ -110,9 +114,10 @@ def multiClassClassification(x, y, **kwargs):
 
     # capture only decision time points
     idx_train = np.nonzero(y_train)
-    idx_test  = np.nonzero(y_test)
+    idx_test = np.nonzero(y_test)
 
-    model = OneVsRestClassifier(RidgeClassifier(alpha=0.0, fit_intercept=False, **kwargs)).fit(x_train[idx_train], y_train[idx_train])
+    model = OneVsRestClassifier(RidgeClassifier(
+        alpha=0.0, fit_intercept=False, **kwargs)).fit(x_train[idx_train], y_train[idx_train])
     score = model.score(x_test[idx_test], y_test[idx_test])
 
     # # confusion matrix
@@ -136,9 +141,10 @@ def multiOutputClassification(x, y, **kwargs):
     x_train, x_test = x
     y_train, y_test = y
 
-    model = MultiOutputClassifier(RidgeClassifier(alpha=0.5, fit_intercept=True, **kwargs)).fit(x_train, y_train)
-    score = model.score(x_test, y_test)    
-    
+    model = MultiOutputClassifier(RidgeClassifier(
+        alpha=0.5, fit_intercept=True, **kwargs)).fit(x_train, y_train)
+    score = model.score(x_test, y_test)
+
     return score
 
 
@@ -148,22 +154,22 @@ def select_model(y):
     variable
     #TODO
     """
-    
+
     if y.dtype in [np.float32, np.float64]:
         if y.ndim == 1:
-            return regression # regression 
+            return regression  # regression
         else:
-            return multiOutputRegression # multilabel regression
+            return multiOutputRegression  # multilabel regression
 
     elif y.dtype in [np.int32, np.int64]:
         if y.ndim == 1:
-            if len(np.unique(y)) == 2: # binary classification
+            if len(np.unique(y)) == 2:  # binary classification
                 return classification
             else:
-                return multiClassClassification # multiclass classification
+                return multiClassClassification  # multiclass classification
         else:
-            return multiOutputClassification # multilabel and/or multiclass classification
-    
+            return multiOutputClassification  # multilabel and/or multiclass classification
+
 
 def run_task(reservoir_states, target, **kwargs):
     """
@@ -193,9 +199,10 @@ def run_task(reservoir_states, target, **kwargs):
     # print('\n PERFORMING TASK ...')
 
     # verify dimensions of x and y
-    x_train, x_test, y_train, y_test = check_xy_dims(x=reservoir_states, y=target)
+    x_train, x_test, y_train, y_test = check_xy_dims(
+        x=reservoir_states, y=target)
 
-    # select training model 
+    # select training model
     func = select_model(y=y_train)
 
     score = func(x=(x_train, x_test), y=(y_train, y_test), **kwargs)

--- a/conn2res/task.py
+++ b/conn2res/task.py
@@ -19,7 +19,7 @@ from sklearn.multioutput import MultiOutputRegressor, MultiOutputClassifier
 from sklearn.metrics import accuracy_score, confusion_matrix, ConfusionMatrixDisplay
 from sklearn.ensemble import RandomForestRegressor
 
-import matplotlib.pyplot as plt
+# import matplotlib.pyplot as plt
 
 
 def check_xy_dims(x, y):

--- a/conn2res/workflows.py
+++ b/conn2res/workflows.py
@@ -15,6 +15,7 @@ from scipy.linalg import eigh
 
 from . import iodata, reservoir, coding
 
+
 def memory_capacity_reservoir(conn, input_nodes, output_nodes, readout_modules=None,
                               readout_nodes=None, resname='EchoStateNetwork',
                               alphas=None, input_gain=1.0, tau_max=20, plot_res=False,
@@ -41,32 +42,34 @@ def memory_capacity_reservoir(conn, input_nodes, output_nodes, readout_modules=N
 
     # normalize connectivity matrix by the spectral radius
     ew, _ = eigh(conn)
-    conn  = conn / np.max(ew)
+    conn = conn / np.max(ew)
 
     # get dataset for memory capacity task
     x, y = iodata.fetch_dataset('MemoryCapacity', tau_max=tau_max)
 
     # create input connectivity matrix
     w_in = np.zeros((1, n_reservoir_nodes))
-    w_in[:,input_nodes] = input_gain
+    w_in[:, input_nodes] = input_gain
 
     # evaluate network performance across various dynamical regimes
-    if alphas is None: alphas = np.linspace(0,2,11)
+    if alphas is None:
+        alphas = np.linspace(0, 2, 11)
 
     df = []
     for alpha in alphas[1:]:
 
-        print(f'\n----------------------- alpha = {alpha} -----------------------')
+        print(
+            f'\n----------------------- alpha = {alpha} -----------------------')
 
         # instantiate an Echo State Network object
         network = reservoir.reservoir(name=resname,
                                       w_ih=w_in,
                                       w_hh=alpha * conn.copy(),
                                       **kwargs
-                                     )
+                                      )
 
         # simulate reservoir states; select only output nodes
-        rs = network.simulate(ext_input=x)[:,output_nodes]
+        rs = network.simulate(ext_input=x)[:, output_nodes]
 
         # remove first tau_max points from reservoir states
         rs = rs[tau_max:]
@@ -78,16 +81,18 @@ def memory_capacity_reservoir(conn, input_nodes, output_nodes, readout_modules=N
         # perform task
         try:
             df_ = coding.encoder(reservoir_states=(rs_train, rs_test),
-                                target=(y_train, y_test),
-                                readout_modules=readout_modules,
-                                readout_nodes=readout_nodes
-                                )
+                                 target=(y_train, y_test),
+                                 readout_modules=readout_modules,
+                                 readout_nodes=readout_nodes
+                                 )
 
             df_['alpha'] = np.round(alpha, 3)
 
             # reorganize the columns
-            if 'module' not in df_.columns: df_['module'] = 'NA'
-            if 'n_nodes' not in df_.columns: df_['n_nodes'] = 'NA'
+            if 'module' not in df_.columns:
+                df_['module'] = 'NA'
+            if 'n_nodes' not in df_.columns:
+                df_['n_nodes'] = 'NA'
             df.append(df_[['module', 'n_nodes', 'alpha', 'score']])
 
         except:
@@ -96,7 +101,8 @@ def memory_capacity_reservoir(conn, input_nodes, output_nodes, readout_modules=N
     df = pd.concat(df, ignore_index=True)
     df['score'] = df['score'].astype(float)
 
-    if plot_res: plot(df, plot_title)
+    if plot_res:
+        plot(df, plot_title)
 
     return df
 
@@ -130,15 +136,17 @@ def memory_capacity_memreservoir(conn, int_nodes, ext_nodes, gr_nodes, readout_m
 
     # get dataset for memory capacity task
     x, y, _ = iodata.fetch_dataset('MemoryCapacity', tau_max=tau_max)
-    x = np.tile(x, (1,len(ext_nodes)))
+    x = np.tile(x, (1, len(ext_nodes)))
 
     # evaluate network performance across various dynamical regimes
-    if alphas is None: alphas = [1.0]
+    if alphas is None:
+        alphas = [1.0]
 
     df = []
     for alpha in alphas:
 
-        print(f'\n----------------------- alpha = {alpha} -----------------------')
+        print(
+            f'\n----------------------- alpha = {alpha} -----------------------')
 
         # instantiate a Memristive Network object
         network = reservoir.reservoir(name=resname,
@@ -147,10 +155,10 @@ def memory_capacity_memreservoir(conn, int_nodes, ext_nodes, gr_nodes, readout_m
                                       ext_nodes=ext_nodes,
                                       gr_nodes=gr_nodes,
                                       **kwargs
-                                     )
+                                      )
 
         # simulate reservoir states; select only output nodes
-        rs = network.simulate(Vext=x, **kwargs)[:,int_nodes]
+        rs = network.simulate(Vext=x, **kwargs)[:, int_nodes]
 
         # remove first tau_max points from reservoir states
         rs = rs[tau_max:]
@@ -170,8 +178,10 @@ def memory_capacity_memreservoir(conn, int_nodes, ext_nodes, gr_nodes, readout_m
             df_['alpha'] = np.round(alpha, 3)
 
             # reorganize the columns
-            if 'module' not in df_.columns: df['module'] = 'NA'
-            if 'n_nodes' not in df_.columns: df_['n_nodes'] = 'NA'
+            if 'module' not in df_.columns:
+                df['module'] = 'NA'
+            if 'n_nodes' not in df_.columns:
+                df_['n_nodes'] = 'NA'
             df.append(df_[['module', 'n_nodes', 'alpha', 'score']])
 
         except:
@@ -180,7 +190,8 @@ def memory_capacity_memreservoir(conn, int_nodes, ext_nodes, gr_nodes, readout_m
     df = pd.concat(df, ignore_index=True)
     df['score'] = df['score'].astype(float)
 
-    if plot_res: plot(df, plot_title)
+    if plot_res:
+        plot(df, plot_title)
 
     return df
 
@@ -193,18 +204,17 @@ def memory_capacity(resname, **kwargs):
         return memory_capacity_memreservoir(resname=resname, **kwargs)
 
 
-
 def plot(df, title):
 
     sns.set(style="ticks", font_scale=2.0)
-    fig = plt.figure(num=1, figsize=(12,10))
+    fig = plt.figure(num=1, figsize=(12, 10))
     ax = plt.subplot(111)
 
     n_modules = len(np.unique(df['module']))
     palette = sns.color_palette('husl', n_modules+1)[:n_modules]
 
     if 'VIS' in list(np.unique(df['module'])):
-        hue_order =['VIS', 'SM', 'DA', 'VA', 'LIM', 'FP', 'DMN']
+        hue_order = ['VIS', 'SM', 'DA', 'VA', 'LIM', 'FP', 'DMN']
     else:
         hue_order = None
 
@@ -217,8 +227,10 @@ def plot(df, title):
 
     sns.despine(offset=10, trim=True)
 
-    if title is not None: plt.title(f'Memory Capacity - {title}')
-    else: plt.title('Memory Capacity')
+    if title is not None:
+        plt.title(f'Memory Capacity - {title}')
+    else:
+        plt.title('Memory Capacity')
 
     plt.plot()
     plt.show()

--- a/conn2res/workflows.py
+++ b/conn2res/workflows.py
@@ -8,12 +8,10 @@ memory capacity of a reservoir
 
 import numpy as np
 import pandas as pd
-import seaborn as sns
-import matplotlib.pyplot as plt
 
 from scipy.linalg import eigh
 
-from . import iodata, reservoir, coding
+from . import iodata, reservoir, coding, plotting
 
 
 def memory_capacity_reservoir(conn, input_nodes, output_nodes, readout_modules=None,
@@ -102,7 +100,12 @@ def memory_capacity_reservoir(conn, input_nodes, output_nodes, readout_modules=N
     df['score'] = df['score'].astype(float)
 
     if plot_res:
-        plot(df, plot_title)
+        if plot_title is not None:
+            plot_title = f'Memory Capacity - {plot_title}'
+        else:
+            plot_title = 'Memory Capacity'
+
+        plotting.plot_performance_curve(df, plot_title)
 
     return df
 
@@ -191,7 +194,12 @@ def memory_capacity_memreservoir(conn, int_nodes, ext_nodes, gr_nodes, readout_m
     df['score'] = df['score'].astype(float)
 
     if plot_res:
-        plot(df, plot_title)
+        if plot_title is not None:
+            plot_title = f'Memory Capacity - {plot_title}'
+        else:
+            plot_title = 'Memory Capacity'
+
+        plotting.plot_performance_curve(df, plot_title)
 
     return df
 
@@ -202,37 +210,3 @@ def memory_capacity(resname, **kwargs):
         return memory_capacity_reservoir(resname=resname, **kwargs)
     elif resname == 'MSSNetwork':
         return memory_capacity_memreservoir(resname=resname, **kwargs)
-
-
-def plot(df, title):
-
-    sns.set(style="ticks", font_scale=2.0)
-    fig = plt.figure(num=1, figsize=(12, 10))
-    ax = plt.subplot(111)
-
-    n_modules = len(np.unique(df['module']))
-    palette = sns.color_palette('husl', n_modules+1)[:n_modules]
-
-    if 'VIS' in list(np.unique(df['module'])):
-        hue_order = ['VIS', 'SM', 'DA', 'VA', 'LIM', 'FP', 'DMN']
-    else:
-        hue_order = None
-
-    sns.lineplot(data=df, x='alpha', y='score',
-                 hue='module',
-                 hue_order=hue_order,
-                 palette=palette,
-                 markers=True,
-                 ax=ax)
-
-    sns.despine(offset=10, trim=True)
-
-    if title is not None:
-        plt.title(f'Memory Capacity - {title}')
-    else:
-        plt.title('Memory Capacity')
-
-    plt.plot()
-    plt.show()
-
-    pass

--- a/conn2res/workflows.py
+++ b/conn2res/workflows.py
@@ -34,19 +34,14 @@ def memory_capacity_reservoir(conn, input_nodes, output_nodes, readout_modules=N
         data frame with task scores
     """
 
-    # scale conenctivity weights between [0,1]
-    conn = (conn - conn.min())/(conn.max() - conn.min())
-    n_reservoir_nodes = len(conn)
-
-    # normalize connectivity matrix by the spectral radius
-    ew, _ = eigh(conn)
-    conn = conn / np.max(ew)
+    # scale conenctivity weights between [0,1] and normalize by spectral radius
+    conn.scale_and_normalize()
 
     # get dataset for memory capacity task
     x, y = iodata.fetch_dataset('MemoryCapacity', tau_max=tau_max)
 
     # create input connectivity matrix
-    w_in = np.zeros((1, n_reservoir_nodes))
+    w_in = np.zeros((1, conn.n_nodes))
     w_in[:, input_nodes] = input_gain
 
     # evaluate network performance across various dynamical regimes
@@ -62,7 +57,7 @@ def memory_capacity_reservoir(conn, input_nodes, output_nodes, readout_modules=N
         # instantiate an Echo State Network object
         network = reservoir.reservoir(name=resname,
                                       w_ih=w_in,
-                                      w_hh=alpha * conn.copy(),
+                                      w_hh=alpha * conn.w,
                                       **kwargs
                                       )
 
@@ -131,11 +126,10 @@ def memory_capacity_memreservoir(conn, int_nodes, ext_nodes, gr_nodes, readout_m
     """
 
     # binarize connectivity matrix
-    conn = conn.astype(bool).astype(int)
+    conn.binarize()
 
     # # normalize connectivity matrix by the spectral radius
-    # ew, _ = eigh(conn)
-    # conn  = conn / np.max(ew)
+    # conn.normalize()
 
     # get dataset for memory capacity task
     x, y, _ = iodata.fetch_dataset('MemoryCapacity', tau_max=tau_max)
@@ -153,7 +147,7 @@ def memory_capacity_memreservoir(conn, int_nodes, ext_nodes, gr_nodes, readout_m
 
         # instantiate a Memristive Network object
         network = reservoir.reservoir(name=resname,
-                                      w=alpha * conn.copy(),
+                                      w=alpha * conn.w,
                                       int_nodes=int_nodes,
                                       ext_nodes=ext_nodes,
                                       gr_nodes=gr_nodes,

--- a/examples/esn.py
+++ b/examples/esn.py
@@ -7,9 +7,7 @@ to perform a task using a human connectomed-informed
 Echo-State network (Jaeger, 2000).
 """
 
-import seaborn as sns
-import matplotlib.pyplot as plt
-from conn2res import reservoir, coding
+from conn2res import reservoir, coding, plotting
 import pandas as pd
 from conn2res import iodata
 from scipy.linalg import eigh
@@ -124,25 +122,4 @@ df_subj['score'] = df_subj['score'].astype(float)
 ############################################################################
 # Now we plot the performance curve
 
-sns.set(style="ticks", font_scale=2.0)
-fig = plt.figure(num=1, figsize=(12, 10))
-ax = plt.subplot(111)
-
-n_modules = len(np.unique(df_subj['module']))
-palette = sns.color_palette('husl', n_modules+1)[:n_modules]
-
-if 'VIS' in list(np.unique(df_subj['module'])):
-    hue_order = ['VIS', 'SM', 'DA', 'VA', 'LIM', 'FP', 'DMN']
-else:
-    hue_order = None
-
-sns.lineplot(data=df_subj, x='alpha', y='score',
-             hue='module',
-             hue_order=hue_order,
-             palette=palette,
-             markers=True,
-             ax=ax)
-sns.despine(offset=10, trim=True)
-plt.title(task)
-plt.plot()
-plt.show()
+plotting.plot_performance_curve(df_subj, task)

--- a/examples/esn.py
+++ b/examples/esn.py
@@ -7,6 +7,14 @@ to perform a task using a human connectomed-informed
 Echo-State network (Jaeger, 2000).
 """
 
+import os
+import seaborn as sns
+import matplotlib.pyplot as plt
+from conn2res import reservoir, coding
+import pandas as pd
+from conn2res import iodata
+from scipy.linalg import eigh
+import numpy as np
 import warnings
 warnings.simplefilter(action='ignore', category=FutureWarning)
 warnings.simplefilter(action='ignore', category=RuntimeWarning)
@@ -17,8 +25,6 @@ warnings.simplefilter(action='ignore', category=UserWarning)
 # connections of the reservoir.  For this we will be using the human connectome
 # parcellated into 1015 brain regions following the Desikan  Killiany atlas
 # (Desikan, et al., 2006).
-import os 
-import numpy as np
 
 PROJ_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DATA_DIR = os.path.join(PROJ_DIR, 'examples', 'data')
@@ -28,26 +34,24 @@ conn = np.load(os.path.join(DATA_DIR, 'connectivity.npy'))
 
 # select one subject
 subj_id = 0
-conn = conn[:,:,subj_id]
+conn = conn[:, :, subj_id]
 n_reservoir_nodes = len(conn)
 
 # scale conenctivity weights between [0,1]
 conn = (conn - conn.min())/(conn.max() - conn.min())
 
 # normalize connectivity matrix by the spectral radius.
-from scipy.linalg import eigh
 
 ew, _ = eigh(conn)
-conn  = conn / np.max(ew)
+conn = conn / np.max(ew)
 
 ###############################################################################
 # Second let's get the data to perform the task. We first generate the data and
 # then we split it into training and test sets. 'x' corresponds to the input
 # signals and 'y' corresponds to the output labels.
-from conn2res import iodata
 
 # get trial-based dataset for task
-task = 'PerceptualDecisionMaking' 
+task = 'PerceptualDecisionMaking'
 n_trials = 1000
 x, y = iodata.fetch_dataset(task, n_trials=n_trials)
 
@@ -63,33 +67,35 @@ y_train, y_test = iodata.split_dataset(y)
 # generated input signal x (x_train and x_test).
 
 # define set of input nodes
-ctx  = np.load(os.path.join(DATA_DIR, 'cortical.npy'))
-subctx_nodes = np.where(ctx == 0)[0] # we use subcortical regions as input nodes
+ctx = np.load(os.path.join(DATA_DIR, 'cortical.npy'))
+# we use subcortical regions as input nodes
+subctx_nodes = np.where(ctx == 0)[0]
 
 n_features = x_train.shape[1]
-input_nodes  = np.random.choice(subctx_nodes, n_features) # we select a randon set of input nodes
-output_nodes = np.where(ctx == 1)[0] # we use cortical regions as output nodes
+# we select a randon set of input nodes
+input_nodes = np.random.choice(subctx_nodes, n_features)
+output_nodes = np.where(ctx == 1)[0]  # we use cortical regions as output nodes
 
 # create input connectivity matrix, which defines the connec-
 # tions between the input layer (source nodes where the input signal is
 # coming from) and the input nodes of the reservoir.
 w_in = np.zeros((n_features, n_reservoir_nodes))
-w_in[np.ix_(np.arange(n_features), input_nodes)] = 10.0 # factor that modulates the activation state of the reservoir
+# factor that modulates the activation state of the reservoir
+w_in[np.ix_(np.arange(n_features), input_nodes)] = 10.0
 
 # We will use resting-state networks as readout modules. These intrinsic networks
 # define different sets of output nodes
 rsn_mapping = np.load(os.path.join(DATA_DIR, 'rsn_mapping.npy'))
-rsn_mapping = rsn_mapping[output_nodes] # we select the mapping only for output nodes 
+# we select the mapping only for output nodes
+rsn_mapping = rsn_mapping[output_nodes]
 
 # evaluate network performance across various dynamical regimes
-# we do so by varying the value of alpha 
-import pandas as pd
-from conn2res import reservoir, coding
+# we do so by varying the value of alpha
 
-alphas = np.linspace(0,2,11)[1:]
+alphas = np.linspace(0, 2, 11)[1:]
 df_subj = []
 for alpha in alphas:
-    
+
     print(f'\n----------------------- alpha = {alpha} -----------------------')
 
     # instantiate an Echo State Network object
@@ -99,8 +105,8 @@ for alpha in alphas:
                                      )
 
     # simulate reservoir states; select only output nodes.
-    rs_train = ESN.simulate(ext_input=x_train)[:,output_nodes]
-    rs_test  = ESN.simulate(ext_input=x_test)[:,output_nodes] 
+    rs_train = ESN.simulate(ext_input=x_train)[:, output_nodes]
+    rs_test = ESN.simulate(ext_input=x_test)[:, output_nodes]
 
     # perform task
     df = coding.encoder(reservoir_states=(rs_train, rs_test),
@@ -111,34 +117,34 @@ for alpha in alphas:
     df['alpha'] = np.round(alpha, 3)
 
     # reorganize the columns
-    if 'module' in df.columns: df_subj.append(df[['module', 'n_nodes', 'alpha', 'score']])
-    else: df_subj.append(df[['alpha', 'score']])
-      
+    if 'module' in df.columns:
+        df_subj.append(df[['module', 'n_nodes', 'alpha', 'score']])
+    else:
+        df_subj.append(df[['alpha', 'score']])
+
 df_subj = pd.concat(df_subj, ignore_index=True)
 df_subj['score'] = df_subj['score'].astype(float)
-   
+
 ############################################################################
 # Now we plot the performance curve
-import matplotlib.pyplot as plt
-import seaborn as sns
 
-sns.set(style="ticks", font_scale=2.0)  
-fig = plt.figure(num=1, figsize=(12,10))
+sns.set(style="ticks", font_scale=2.0)
+fig = plt.figure(num=1, figsize=(12, 10))
 ax = plt.subplot(111)
 
 n_modules = len(np.unique(df_subj['module']))
 palette = sns.color_palette('husl', n_modules+1)[:n_modules]
 
 if 'VIS' in list(np.unique(df_subj['module'])):
-    hue_order =['VIS', 'SM', 'DA', 'VA', 'LIM', 'FP', 'DMN']
+    hue_order = ['VIS', 'SM', 'DA', 'VA', 'LIM', 'FP', 'DMN']
 else:
     hue_order = None
 
-sns.lineplot(data=df_subj, x='alpha', y='score', 
-             hue='module', 
+sns.lineplot(data=df_subj, x='alpha', y='score',
+             hue='module',
              hue_order=hue_order,
-             palette=palette, 
-             markers=True, 
+             palette=palette,
+             markers=True,
              ax=ax)
 sns.despine(offset=10, trim=True)
 plt.title(task)

--- a/examples/esn.py
+++ b/examples/esn.py
@@ -10,7 +10,6 @@ Echo-State network (Jaeger, 2000).
 from conn2res import reservoir, coding, plotting
 import pandas as pd
 from conn2res import iodata
-from scipy.linalg import eigh
 import numpy as np
 import warnings
 warnings.simplefilter(action='ignore', category=FutureWarning)
@@ -23,21 +22,11 @@ warnings.simplefilter(action='ignore', category=UserWarning)
 # parcellated into 1015 brain regions following the Desikan  Killiany atlas
 # (Desikan, et al., 2006).
 
-# load connectivity data
-conn = iodata.load_file('connectivity.npy')
+# load connectivity data of one subject
+conn = reservoir.Conn(subj_id=0)
 
-# select one subject
-subj_id = 0
-conn = conn[:, :, subj_id]
-n_reservoir_nodes = len(conn)
-
-# scale conenctivity weights between [0,1]
-conn = (conn - conn.min())/(conn.max() - conn.min())
-
-# normalize connectivity matrix by the spectral radius.
-
-ew, _ = eigh(conn)
-conn = conn / np.max(ew)
+# scale conenctivity weights between [0,1] and normalize by spectral radius
+conn.scale_and_normalize()
 
 ###############################################################################
 # Second let's get the data to perform the task. We first generate the data and
@@ -60,20 +49,20 @@ y_train, y_test = iodata.split_dataset(y)
 # Third we will simulate the dynamics of the reservoir using the previously
 # generated input signal x (x_train and x_test).
 
-# define set of input nodes
-ctx = iodata.load_file('cortical.npy')
-# we use subcortical regions as input nodes
-subctx_nodes = np.where(ctx == 0)[0]
-
+# number of features in task data
 n_features = x_train.shape[1]
-# we select a randon set of input nodes
-input_nodes = np.random.choice(subctx_nodes, n_features)
-output_nodes = np.where(ctx == 1)[0]  # we use cortical regions as output nodes
+
+# we select a random set of input nodes from subcortical regions
+input_nodes = conn.get_nodes(
+    'random', nodes_from=conn.get_nodes('subctx'), n_nodes=n_features)
+
+# we use cortical regions as output nodes
+output_nodes = conn.get_nodes('ctx')
 
 # create input connectivity matrix, which defines the connec-
 # tions between the input layer (source nodes where the input signal is
 # coming from) and the input nodes of the reservoir.
-w_in = np.zeros((n_features, n_reservoir_nodes))
+w_in = np.zeros((n_features, conn.n_nodes))
 # factor that modulates the activation state of the reservoir
 w_in[np.ix_(np.arange(n_features), input_nodes)] = 10.0
 
@@ -81,7 +70,7 @@ w_in[np.ix_(np.arange(n_features), input_nodes)] = 10.0
 # define different sets of output nodes
 rsn_mapping = iodata.load_file('rsn_mapping.npy')
 # we select the mapping only for output nodes
-rsn_mapping = rsn_mapping[output_nodes]
+rsn_mapping = rsn_mapping[conn.idx_node][output_nodes]
 
 # evaluate network performance across various dynamical regimes
 # we do so by varying the value of alpha
@@ -94,7 +83,7 @@ for alpha in alphas:
 
     # instantiate an Echo State Network object
     ESN = reservoir.EchoStateNetwork(w_ih=w_in,
-                                     w_hh=alpha * conn.copy(),
+                                     w_hh=alpha * conn.w,
                                      activation_function='tanh',
                                      )
 

--- a/examples/esn.py
+++ b/examples/esn.py
@@ -7,7 +7,6 @@ to perform a task using a human connectomed-informed
 Echo-State network (Jaeger, 2000).
 """
 
-import os
 import seaborn as sns
 import matplotlib.pyplot as plt
 from conn2res import reservoir, coding
@@ -26,11 +25,8 @@ warnings.simplefilter(action='ignore', category=UserWarning)
 # parcellated into 1015 brain regions following the Desikan  Killiany atlas
 # (Desikan, et al., 2006).
 
-PROJ_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-DATA_DIR = os.path.join(PROJ_DIR, 'examples', 'data')
-
 # load connectivity data
-conn = np.load(os.path.join(DATA_DIR, 'connectivity.npy'))
+conn = iodata.load_file('connectivity.npy')
 
 # select one subject
 subj_id = 0
@@ -67,7 +63,7 @@ y_train, y_test = iodata.split_dataset(y)
 # generated input signal x (x_train and x_test).
 
 # define set of input nodes
-ctx = np.load(os.path.join(DATA_DIR, 'cortical.npy'))
+ctx = iodata.load_file('cortical.npy')
 # we use subcortical regions as input nodes
 subctx_nodes = np.where(ctx == 0)[0]
 
@@ -85,7 +81,7 @@ w_in[np.ix_(np.arange(n_features), input_nodes)] = 10.0
 
 # We will use resting-state networks as readout modules. These intrinsic networks
 # define different sets of output nodes
-rsn_mapping = np.load(os.path.join(DATA_DIR, 'rsn_mapping.npy'))
+rsn_mapping = iodata.load_file('rsn_mapping.npy')
 # we select the mapping only for output nodes
 rsn_mapping = rsn_mapping[output_nodes]
 

--- a/examples/memory_capacity.py
+++ b/examples/memory_capacity.py
@@ -8,9 +8,8 @@ Echo-State network while playing with the dynamics of the reservoir
 (Jaeger, 2000).
 """
 
-from conn2res import workflows
+from conn2res import workflows, iodata
 import numpy as np
-import os
 import warnings
 warnings.simplefilter(action='ignore', category=UserWarning)
 
@@ -20,11 +19,8 @@ warnings.simplefilter(action='ignore', category=UserWarning)
 # parcellated into 1015 brain regions following the Desikan  Killiany atlas
 # (Desikan, et al., 2006).
 
-PROJ_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-DATA_DIR = os.path.join(PROJ_DIR, 'examples', 'data')
-
 # load connectivity data
-conn = np.load(os.path.join(DATA_DIR, 'connectivity.npy'))
+conn = iodata.load_file('connectivity.npy')
 n_reservoir_nodes = len(conn)
 
 # select one subject
@@ -32,7 +28,7 @@ subj_id = 55
 conn = conn[:, :, subj_id]
 
 # define set of nodes
-ctx = np.load(os.path.join(DATA_DIR, 'cortical.npy'))
+ctx = iodata.load_file('cortical.npy')
 
 # set of nodes for Echo State Network
 # we use subcortical regions as input nodes
@@ -51,7 +47,7 @@ int_nodes = np.setdiff1d(nodes, np.union1d(gr_nodes, ext_nodes))
 
 # We will use resting-state networks as readout modules. These intrinsic networks
 # define different sets of output nodes
-rsn_mapping = np.load(os.path.join(DATA_DIR, 'rsn_mapping.npy'))
+rsn_mapping = iodata.load_file('rsn_mapping.npy')
 
 # Evaluate memory capacity
 

--- a/examples/memory_capacity.py
+++ b/examples/memory_capacity.py
@@ -8,6 +8,9 @@ Echo-State network while playing with the dynamics of the reservoir
 (Jaeger, 2000).
 """
 
+from conn2res import workflows
+import numpy as np
+import os
 import warnings
 warnings.simplefilter(action='ignore', category=UserWarning)
 
@@ -16,8 +19,6 @@ warnings.simplefilter(action='ignore', category=UserWarning)
 # connections of the reservoir.  For this we will be using the human connectome
 # parcellated into 1015 brain regions following the Desikan  Killiany atlas
 # (Desikan, et al., 2006).
-import os
-import numpy as np
 
 PROJ_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DATA_DIR = os.path.join(PROJ_DIR, 'examples', 'data')
@@ -28,27 +29,31 @@ n_reservoir_nodes = len(conn)
 
 # select one subject
 subj_id = 55
-conn = conn[:,:,subj_id]
+conn = conn[:, :, subj_id]
 
 # define set of nodes
-ctx  = np.load(os.path.join(DATA_DIR, 'cortical.npy'))
+ctx = np.load(os.path.join(DATA_DIR, 'cortical.npy'))
 
 # set of nodes for Echo State Network
-input_nodes  = np.where(ctx == 0)[0] # we use subcortical regions as input nodes
-output_nodes = np.where(ctx == 1)[0] # we use cortical regions as output nodes
+# we use subcortical regions as input nodes
+input_nodes = np.where(ctx == 0)[0]
+output_nodes = np.where(ctx == 1)[0]  # we use cortical regions as output nodes
 
-#set of nodes for MSSNetwork
-nodes = np.arange(n_reservoir_nodes) # this is the set of all nodes in the network
-gr_nodes  = np.random.choice(np.where(ctx == 1)[0], 1) # we select a single random ground node from cortical regions
-ext_nodes = np.where(ctx == 0)[0] # we select a random set of input nodes from subcortical regions
-int_nodes = np.setdiff1d(nodes, np.union1d(gr_nodes,ext_nodes)) # we use the reamining cortical regions as output nodes
+# set of nodes for MSSNetwork
+# this is the set of all nodes in the network
+nodes = np.arange(n_reservoir_nodes)
+# we select a single random ground node from cortical regions
+gr_nodes = np.random.choice(np.where(ctx == 1)[0], 1)
+# we select a random set of input nodes from subcortical regions
+ext_nodes = np.where(ctx == 0)[0]
+# we use the reamining cortical regions as output nodes
+int_nodes = np.setdiff1d(nodes, np.union1d(gr_nodes, ext_nodes))
 
 # We will use resting-state networks as readout modules. These intrinsic networks
 # define different sets of output nodes
 rsn_mapping = np.load(os.path.join(DATA_DIR, 'rsn_mapping.npy'))
 
 # Evaluate memory capacity
-from conn2res import workflows
 
 # echo state network
 MC = workflows.memory_capacity(resname='EchoStateNetwork',
@@ -56,7 +61,7 @@ MC = workflows.memory_capacity(resname='EchoStateNetwork',
                                input_nodes=input_nodes,
                                output_nodes=output_nodes,
                                readout_modules=rsn_mapping[output_nodes],
-                               alphas=np.linspace(0,4,21),
+                               alphas=np.linspace(0, 4, 21),
                                input_gain=1.0,
                                tau_max=16,
                                plot_res=True,

--- a/examples/memory_capacity.py
+++ b/examples/memory_capacity.py
@@ -8,7 +8,7 @@ Echo-State network while playing with the dynamics of the reservoir
 (Jaeger, 2000).
 """
 
-from conn2res import workflows, iodata
+from conn2res import reservoir, workflows, iodata
 import numpy as np
 import warnings
 warnings.simplefilter(action='ignore', category=UserWarning)
@@ -19,31 +19,22 @@ warnings.simplefilter(action='ignore', category=UserWarning)
 # parcellated into 1015 brain regions following the Desikan  Killiany atlas
 # (Desikan, et al., 2006).
 
-# load connectivity data
-conn = iodata.load_file('connectivity.npy')
-n_reservoir_nodes = len(conn)
-
-# select one subject
-subj_id = 55
-conn = conn[:, :, subj_id]
-
-# define set of nodes
-ctx = iodata.load_file('cortical.npy')
+# load connectivity data of one subject
+conn = reservoir.Conn(subj_id=55)
 
 # set of nodes for Echo State Network
-# we use subcortical regions as input nodes
-input_nodes = np.where(ctx == 0)[0]
-output_nodes = np.where(ctx == 1)[0]  # we use cortical regions as output nodes
+input_nodes = conn.get_nodes('subctx')
+output_nodes = conn.get_nodes('ctx')
 
 # set of nodes for MSSNetwork
-# this is the set of all nodes in the network
-nodes = np.arange(n_reservoir_nodes)
 # we select a single random ground node from cortical regions
-gr_nodes = np.random.choice(np.where(ctx == 1)[0], 1)
-# we select a random set of input nodes from subcortical regions
-ext_nodes = np.where(ctx == 0)[0]
+gr_nodes = conn.get_nodes(
+    'random', nodes_from=conn.get_nodes('ctx'), n_nodes=1)
+# we select external nodes as random set of input nodes from subcortical regions
+ext_nodes = conn.get_nodes('subctx')
 # we use the reamining cortical regions as output nodes
-int_nodes = np.setdiff1d(nodes, np.union1d(gr_nodes, ext_nodes))
+int_nodes = conn.get_nodes(
+    'all', nodes_without=np.union1d(gr_nodes, ext_nodes))
 
 # We will use resting-state networks as readout modules. These intrinsic networks
 # define different sets of output nodes
@@ -56,7 +47,7 @@ MC = workflows.memory_capacity(resname='EchoStateNetwork',
                                conn=conn,
                                input_nodes=input_nodes,
                                output_nodes=output_nodes,
-                               readout_modules=rsn_mapping[output_nodes],
+                               readout_modules=rsn_mapping[conn.idx_node][output_nodes],
                                alphas=np.linspace(0, 4, 21),
                                input_gain=1.0,
                                tau_max=16,
@@ -70,7 +61,7 @@ MC = workflows.memory_capacity(resname='EchoStateNetwork',
 #                                 int_nodes=int_nodes,
 #                                 ext_nodes=ext_nodes,
 #                                 gr_nodes=gr_nodes,
-#                                 # readout_modules=rsn_mapping[int_nodes],
+#                                 # readout_modules=rsn_mapping[conn.idx_node][int_nodes],
 #                                 alphas=[1.0],
 #                                 input_gain=1.0,
 #                                 tau_max=16,

--- a/examples/mssn.py
+++ b/examples/mssn.py
@@ -7,6 +7,13 @@ to perform a task using a human connectomed-informed
 Memristive network
 """
 
+import seaborn as sns
+import matplotlib.pyplot as plt
+from conn2res import reservoir, coding
+import pandas as pd
+from conn2res import iodata
+import numpy as np
+import os
 import warnings
 warnings.simplefilter(action='ignore', category=FutureWarning)
 warnings.simplefilter(action='ignore', category=RuntimeWarning)
@@ -17,8 +24,6 @@ warnings.simplefilter(action='ignore', category=UserWarning)
 # connections of the reservoir.  For this we will be using the human connectome
 # parcellated into 1015 brain regions following the Desikan  Killiany atlas
 # (Desikan, et al., 2006).
-import os
-import numpy as np
 
 PROJ_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DATA_DIR = os.path.join(PROJ_DIR, 'examples', 'data')
@@ -28,7 +33,7 @@ conn = np.load(os.path.join(DATA_DIR, 'connectivity.npy'))
 
 # select one subject
 subj_id = 10
-conn = conn[:,:,subj_id]
+conn = conn[:, :, subj_id]
 n_reservoir_nodes = len(conn)
 
 # binarize connectivity matrix
@@ -44,7 +49,6 @@ conn = conn.astype(bool).astype(int)
 # Second let's get the data to perform the task. We first generate the data and
 # then we split it into training and test sets. 'x' corresponds to the input
 # signals and 'y' corresponds to the output labels.
-from conn2res import iodata
 
 # get trial-based dataset for task
 task = 'PerceptualDecisionMaking'
@@ -63,33 +67,36 @@ y_train, y_test = iodata.split_dataset(y)
 # generated input signal x (x_train and x_test).
 
 # define sets of internal, external and ground nodes
-ctx  = np.load(os.path.join(DATA_DIR, 'cortical.npy'))
+ctx = np.load(os.path.join(DATA_DIR, 'cortical.npy'))
 
 n_features = x_train.shape[1]
 nodes = np.arange(n_reservoir_nodes)
-gr_nodes  = np.random.choice(np.where(ctx == 1)[0], 1) # we select a single random ground node from cortical regions
-ext_nodes = np.random.choice(np.where(ctx == 0)[0], n_features) # we select a random set of input nodes from subcortical regions
-int_nodes = np.setdiff1d(nodes, np.union1d(gr_nodes,ext_nodes)) # we use the reamining cortical regions as output nodes
+# we select a single random ground node from cortical regions
+gr_nodes = np.random.choice(np.where(ctx == 1)[0], 1)
+# we select a random set of input nodes from subcortical regions
+ext_nodes = np.random.choice(np.where(ctx == 0)[0], n_features)
+# we use the reamining cortical regions as output nodes
+int_nodes = np.setdiff1d(nodes, np.union1d(gr_nodes, ext_nodes))
 
-# However, because not all subcortical nodes are used as input nodes in this case, we create 
-# a new set of output nodes that include (only) all cortical regions but those corresponding 
+# However, because not all subcortical nodes are used as input nodes in this case, we create
+# a new set of output nodes that include (only) all cortical regions but those corresponding
 # to grounded nodes
-output_nodes = np.setdiff1d(np.where(ctx == 1)[0], gr_nodes) # nodes actually used to perform the task
+# nodes actually used to perform the task
+output_nodes = np.setdiff1d(np.where(ctx == 1)[0], gr_nodes)
 
 # We will use resting-state networks as readout modules. These intrinsic networks
 # define different sets of output nodes
 rsn_mapping = np.load(os.path.join(DATA_DIR, 'rsn_mapping.npy'))
-rsn_mapping = rsn_mapping[output_nodes] # we select the mapping only for output nodes 
+# we select the mapping only for output nodes
+rsn_mapping = rsn_mapping[output_nodes]
 
 # evaluate network performance across various dynamical regimes
-# we do so by varying the value of alpha 
-import pandas as pd
-from conn2res import reservoir, coding
+# we do so by varying the value of alpha
 
-alphas = np.linspace(0,2,11)[1:]
+alphas = np.linspace(0, 2, 11)[1:]
 df_subj = []
 for alpha in alphas:
-    
+
     print(f'\n----------------------- alpha = {alpha} -----------------------')
 
     # instantiate an Memristive Network object
@@ -100,9 +107,9 @@ for alpha in alphas:
                                )
 
     # simulate reservoir states; select only readout nodes.
-    rs_train = MMN.simulate(Vext=x_train[:], mode='forward')[:,output_nodes]
-    rs_test  = MMN.simulate(Vext=x_test[:],  mode='forward')[:,output_nodes] 
-    
+    rs_train = MMN.simulate(Vext=x_train[:], mode='forward')[:, output_nodes]
+    rs_test = MMN.simulate(Vext=x_test[:],  mode='forward')[:, output_nodes]
+
     # perform task
     df = coding.encoder(reservoir_states=(rs_train, rs_test),
                         target=(y_train, y_test),
@@ -116,32 +123,30 @@ for alpha in alphas:
         df_subj.append(df[['module', 'n_nodes', 'alpha', 'score']])
     else:
         df_subj.append(df[['alpha', 'score']])
-      
+
 df_subj = pd.concat(df_subj, ignore_index=True)
 df_subj['score'] = df_subj['score'].astype(float)
-   
+
 #############################################################################
 # Now we plot the performance curve
-import matplotlib.pyplot as plt
-import seaborn as sns
 
-sns.set(style="ticks", font_scale=2.0)  
-fig = plt.figure(num=1, figsize=(12,10))
+sns.set(style="ticks", font_scale=2.0)
+fig = plt.figure(num=1, figsize=(12, 10))
 ax = plt.subplot(111)
 
 n_modules = len(np.unique(df_subj['module']))
 palette = sns.color_palette('husl', n_modules+1)[:n_modules]
 
 if 'VIS' in list(np.unique(df_subj['module'])):
-    hue_order =['VIS', 'SM', 'DA', 'VA', 'LIM', 'FP', 'DMN']
+    hue_order = ['VIS', 'SM', 'DA', 'VA', 'LIM', 'FP', 'DMN']
 else:
     hue_order = None
 
-sns.lineplot(data=df_subj, x='alpha', y='score', 
-             hue='module', 
+sns.lineplot(data=df_subj, x='alpha', y='score',
+             hue='module',
              hue_order=hue_order,
-             palette=palette, 
-             markers=True, 
+             palette=palette,
+             markers=True,
              ax=ax)
 sns.despine(offset=10, trim=True)
 plt.title(task)

--- a/examples/mssn.py
+++ b/examples/mssn.py
@@ -9,11 +9,9 @@ Memristive network
 
 import seaborn as sns
 import matplotlib.pyplot as plt
-from conn2res import reservoir, coding
+from conn2res import reservoir, coding, iodata
 import pandas as pd
-from conn2res import iodata
 import numpy as np
-import os
 import warnings
 warnings.simplefilter(action='ignore', category=FutureWarning)
 warnings.simplefilter(action='ignore', category=RuntimeWarning)
@@ -25,11 +23,8 @@ warnings.simplefilter(action='ignore', category=UserWarning)
 # parcellated into 1015 brain regions following the Desikan  Killiany atlas
 # (Desikan, et al., 2006).
 
-PROJ_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-DATA_DIR = os.path.join(PROJ_DIR, 'examples', 'data')
-
 # load connectivity data
-conn = np.load(os.path.join(DATA_DIR, 'connectivity.npy'))
+conn = iodata.load_file('connectivity.npy')
 
 # select one subject
 subj_id = 10
@@ -67,7 +62,7 @@ y_train, y_test = iodata.split_dataset(y)
 # generated input signal x (x_train and x_test).
 
 # define sets of internal, external and ground nodes
-ctx = np.load(os.path.join(DATA_DIR, 'cortical.npy'))
+ctx = iodata.load_file('cortical.npy')
 
 n_features = x_train.shape[1]
 nodes = np.arange(n_reservoir_nodes)
@@ -86,7 +81,7 @@ output_nodes = np.setdiff1d(np.where(ctx == 1)[0], gr_nodes)
 
 # We will use resting-state networks as readout modules. These intrinsic networks
 # define different sets of output nodes
-rsn_mapping = np.load(os.path.join(DATA_DIR, 'rsn_mapping.npy'))
+rsn_mapping = iodata.load_file('rsn_mapping.npy')
 # we select the mapping only for output nodes
 rsn_mapping = rsn_mapping[output_nodes]
 

--- a/examples/mssn.py
+++ b/examples/mssn.py
@@ -7,9 +7,7 @@ to perform a task using a human connectomed-informed
 Memristive network
 """
 
-import seaborn as sns
-import matplotlib.pyplot as plt
-from conn2res import reservoir, coding, iodata
+from conn2res import reservoir, coding, iodata, plotting
 import pandas as pd
 import numpy as np
 import warnings
@@ -125,25 +123,4 @@ df_subj['score'] = df_subj['score'].astype(float)
 #############################################################################
 # Now we plot the performance curve
 
-sns.set(style="ticks", font_scale=2.0)
-fig = plt.figure(num=1, figsize=(12, 10))
-ax = plt.subplot(111)
-
-n_modules = len(np.unique(df_subj['module']))
-palette = sns.color_palette('husl', n_modules+1)[:n_modules]
-
-if 'VIS' in list(np.unique(df_subj['module'])):
-    hue_order = ['VIS', 'SM', 'DA', 'VA', 'LIM', 'FP', 'DMN']
-else:
-    hue_order = None
-
-sns.lineplot(data=df_subj, x='alpha', y='score',
-             hue='module',
-             hue_order=hue_order,
-             palette=palette,
-             markers=True,
-             ax=ax)
-sns.despine(offset=10, trim=True)
-plt.title(task)
-plt.plot()
-plt.show()
+plotting.plot_performance_curve(df_subj, task)

--- a/examples/mssn.py
+++ b/examples/mssn.py
@@ -21,22 +21,14 @@ warnings.simplefilter(action='ignore', category=UserWarning)
 # parcellated into 1015 brain regions following the Desikan  Killiany atlas
 # (Desikan, et al., 2006).
 
-# load connectivity data
-conn = iodata.load_file('connectivity.npy')
-
-# select one subject
-subj_id = 10
-conn = conn[:, :, subj_id]
-n_reservoir_nodes = len(conn)
+# load connectivity data of one subject
+conn = reservoir.Conn(subj_id=10)
 
 # binarize connectivity matrix
-conn = conn.astype(bool).astype(int)
+conn.binarize()
 
-# # normalize connectivity matrix by the spectral radius.
-# from scipy.linalg import eigh
-
-# ew, _ = eigh(conn)
-# conn  = conn / np.max(ew)
+# # normalize connectivity matrix by the spectral radius
+# conn.normalize()
 
 ###############################################################################
 # Second let's get the data to perform the task. We first generate the data and
@@ -62,26 +54,29 @@ y_train, y_test = iodata.split_dataset(y)
 # define sets of internal, external and ground nodes
 ctx = iodata.load_file('cortical.npy')
 
+# number of features in task data
 n_features = x_train.shape[1]
-nodes = np.arange(n_reservoir_nodes)
-# we select a single random ground node from cortical regions
-gr_nodes = np.random.choice(np.where(ctx == 1)[0], 1)
-# we select a random set of input nodes from subcortical regions
-ext_nodes = np.random.choice(np.where(ctx == 0)[0], n_features)
-# we use the reamining cortical regions as output nodes
-int_nodes = np.setdiff1d(nodes, np.union1d(gr_nodes, ext_nodes))
 
-# However, because not all subcortical nodes are used as input nodes in this case, we create
-# a new set of output nodes that include (only) all cortical regions but those corresponding
-# to grounded nodes
-# nodes actually used to perform the task
-output_nodes = np.setdiff1d(np.where(ctx == 1)[0], gr_nodes)
+# we select a single random ground node from cortical regions
+gr_nodes = conn.get_nodes(
+    'random', nodes_from=conn.get_nodes('ctx'), n_nodes=1)
+
+# we use the remaining cortical regions as output nodes
+output_nodes = conn.get_nodes('ctx', nodes_without=gr_nodes)
+
+# we select external nodes as random set of input nodes from subcortical regions
+ext_nodes = conn.get_nodes(
+    'random', nodes_from=conn.get_nodes('subctx'), n_nodes=n_features)
+
+# we select internal nodes as all nodes except of ground nodes external nodes
+int_nodes = conn.get_nodes(
+    'all', nodes_without=np.union1d(gr_nodes, ext_nodes))
 
 # We will use resting-state networks as readout modules. These intrinsic networks
 # define different sets of output nodes
 rsn_mapping = iodata.load_file('rsn_mapping.npy')
 # we select the mapping only for output nodes
-rsn_mapping = rsn_mapping[output_nodes]
+rsn_mapping = rsn_mapping[conn.idx_node][output_nodes]
 
 # evaluate network performance across various dynamical regimes
 # we do so by varying the value of alpha
@@ -93,7 +88,7 @@ for alpha in alphas:
     print(f'\n----------------------- alpha = {alpha} -----------------------')
 
     # instantiate an Memristive Network object
-    MMN = reservoir.MSSNetwork(w=alpha * conn.copy(),
+    MMN = reservoir.MSSNetwork(w=alpha * conn.w,
                                int_nodes=int_nodes,
                                ext_nodes=ext_nodes,
                                gr_nodes=gr_nodes

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 
+import versioneer
 import os
 from setuptools import setup
 import sys
 
 sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 
-import versioneer
 
 if __name__ == "__main__":
     setup(name='conn2res',


### PR DESCRIPTION
This new feature adds a Conn class to the reservoir.py module to have all attributes and operations on weighted or unweighted connectivity data in one object.

At the moment, I proposed a simple usage of this class in the reservoir, where the EchoStateNetwork class takes only the weight matrix of the Conn class as input (I also updated this basic usage in the mssn example and workflow).

A more advanced version could be, for instance, if the EchoStateNetwork, and the MemristiveReservoir/MSSNetwork took the Conn class as input. In this case, all operations that are performed on the connectivity matrix inside the MSSNetwork class (e.g., calling check_symmetric, make_symmetric) could be moved into the Conn class. As I don't really use the MSSNetwork class, I didnt' want to touch that part of the code to avoid messing up something. 